### PR TITLE
Use the new errors syntax of JSON-API as required

### DIFF
--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -8,9 +8,30 @@ export default DS.RESTAdapter.extend({
   isInvalid: function(status, headers, payload) {
     if (VALIDATION_ERROR_STATUSES.indexOf(status) >= 0) {
       // handleResponse expects the erros in the errors property
-      payload.errors = payload.modelState;
+      payload.errors = this.errorsHashToArray(payload.modelState);
       return true;
     }
     return false;
+  },
+
+  errorsHashToArray: function (errors) {
+    let out = [];
+
+    if (Ember.isPresent(errors)) {
+      Object.keys(errors).forEach(function(key) {
+        let messages = Ember.makeArray(errors[key]);
+        for (let i = 0; i < messages.length; i++) {
+          out.push({
+            title: 'Invalid Attribute',
+            detail: messages[i],
+            source: {
+              pointer: `/data/attributes/${key}`
+            }
+          });
+        }
+      });
+    }
+
+    return out;
   }
 });

--- a/addon/serializers/web-api.js
+++ b/addon/serializers/web-api.js
@@ -50,19 +50,15 @@ export default DS.RESTSerializer.extend({
     }
   },
 
-  normalizeErrors: function normalizeErrors(typeClass, payload) {
-    let payloadKey = `${typeClass.modelName}.`,
-        keys = Object.keys(payload);
+  extractErrors: function (store, typeClass, payload, id) {
+    let payloadErrors = null;
+    if (payload && typeof payload === 'object' && payload.errors) {
+      this.clearModelName(payload.errors, typeClass.modelName);
+    }
 
-    keys.forEach(function(key) {
-      if(payload.hasOwnProperty(key)) {
-        payload[key.replace(payloadKey, '').camelize()] = payload[key];
-        delete payload[key];
-      }
-    });
-    return this._super(typeClass, payload);
+    return this._super(store, typeClass, payload, id);
   },
-
+  
   clearModelName: function(errors, modelName) {
     // Since the new JSON API InvalidError structure appeared we need to handle it.
     // I know it sucks but for now the extractErrors hook gets the data pre-coocked into


### PR DESCRIPTION
Fixed the issue you mentions in order to work with the new ember-data error syntax
