### PR TITLE
Refactor Server-Side Validation Error Handling

### DIFF
--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import {camelize} from 'ember-inflector';
 
 const VALIDATION_ERROR_STATUSES = [400, 422];
 
@@ -22,7 +21,7 @@ export default DS.RESTAdapter.extend({
 
     if (jsonIsObject && json.modelState) {
       Object.keys(json.modelState).forEach(key => {
-        let newKey = camelize(key.substring(key.indexOf('.') + 1));
+        let newKey = key.substring(key.indexOf('.') + 1).camelize();
         strippedErrors[newKey] = json.modelState[key];
       });
 

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -28,7 +28,7 @@ export default DS.RESTAdapter.extend({
         strippedErrors[newKey] = json.modelState[key];
       });
 
-      json.errors = this.strippedErrors;
+      json.errors = strippedErrors;
 
       delete json.modelState;
     }

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -12,6 +12,8 @@ export default DS.RESTAdapter.extend({
 
   // Override the parseErrorResponse method from RESTAdapter
   // so that we can munge the modelState into an errors collection.
+  // The source of the original method can be found at:
+  // https://github.com/emberjs/data/blob/v2.1.0/packages/ember-data/lib/adapters/rest-adapter.js#L899
   parseErrorResponse: function(responseText) {
     let json = this._super(responseText),
         strippedErrors = {},

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -10,6 +10,8 @@ export default DS.RESTAdapter.extend({
     return VALIDATION_ERROR_STATUSES.indexOf(status) >= 0;
   },
 
+  // Override the parseErrorResponse method from RESTAdapter
+  // so that we can munge the modelState into an errors collection.
   parseErrorResponse: function(responseText) {
     let json = this._super(responseText),
         strippedErrors = {},
@@ -25,32 +27,11 @@ export default DS.RESTAdapter.extend({
         strippedErrors[newKey] = json.modelState[key];
       });
 
-      json.errors = this._errorsHashToArray(strippedErrors);
+      json.errors = this.strippedErrors;
 
       delete json.modelState;
     }
 
     return json;
-  },
-
-  _errorsHashToArray: function (errors) {
-    let out = [];
-
-    if (Ember.isPresent(errors)) {
-      Object.keys(errors).forEach(function(key) {
-        let messages = Ember.makeArray(errors[key]);
-        for (let i = 0; i < messages.length; i++) {
-          out.push({
-            title: 'Invalid Attribute',
-            detail: messages[i],
-            source: {
-              pointer: `/data/attributes/${key}`
-            }
-          });
-        }
-      });
-    }
-
-    return out;
   }
 });

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 
 const VALIDATION_ERROR_STATUSES = [400, 422];

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -1,12 +1,11 @@
 import DS from 'ember-data';
-import Ember from 'ember';
 
 const VALIDATION_ERROR_STATUSES = [400, 422];
 
 export default DS.RESTAdapter.extend({
   namespace: 'api',
 
-  isInvalid: function(status, headers, payload) {
+  isInvalid: function(status) {
     return VALIDATION_ERROR_STATUSES.indexOf(status) >= 0;
   }
 });

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -1,4 +1,6 @@
+import Ember from 'ember';
 import DS from 'ember-data';
+import {camelize} from 'ember-inflector';
 
 const VALIDATION_ERROR_STATUSES = [400, 422];
 
@@ -7,5 +9,49 @@ export default DS.RESTAdapter.extend({
 
   isInvalid: function(status) {
     return VALIDATION_ERROR_STATUSES.indexOf(status) >= 0;
+  },
+
+  parseErrorResponse: function(responseText) {
+    let json = this._super(responseText),
+        strippedErrors = {},
+        jsonIsObject = json && (typeof json === 'object');
+
+    if (jsonIsObject && json.message) {
+      delete json.message;
+    }
+
+    if (jsonIsObject && json.modelState) {
+      Object.keys(json.modelState).forEach(key => {
+        let newKey = camelize(key.substring(key.indexOf('.') + 1));
+        strippedErrors[newKey] = json.modelState[key];
+      });
+
+      json.errors = this._errorsHashToArray(strippedErrors);
+
+      delete json.modelState;
+    }
+
+    return json;
+  },
+
+  _errorsHashToArray: function (errors) {
+    let out = [];
+
+    if (Ember.isPresent(errors)) {
+      Object.keys(errors).forEach(function(key) {
+        let messages = Ember.makeArray(errors[key]);
+        for (let i = 0; i < messages.length; i++) {
+          out.push({
+            title: 'Invalid Attribute',
+            detail: messages[i],
+            source: {
+              pointer: `/data/attributes/${key}`
+            }
+          });
+        }
+      });
+    }
+
+    return out;
   }
 });

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -7,32 +7,6 @@ export default DS.RESTAdapter.extend({
   namespace: 'api',
 
   isInvalid: function(status, headers, payload) {
-    if (VALIDATION_ERROR_STATUSES.indexOf(status) >= 0) {
-      // handleResponse expects the erros in the errors property
-      payload.errors = this.errorsHashToArray(payload.modelState);
-      return true;
-    }
-    return false;
-  },
-
-  errorsHashToArray: function (errors) {
-    let out = [];
-
-    if (Ember.isPresent(errors)) {
-      Object.keys(errors).forEach(function(key) {
-        let messages = Ember.makeArray(errors[key]);
-        for (let i = 0; i < messages.length; i++) {
-          out.push({
-            title: 'Invalid Attribute',
-            detail: messages[i],
-            source: {
-              pointer: `/data/attributes/${key}`
-            }
-          });
-        }
-      });
-    }
-
-    return out;
+    return VALIDATION_ERROR_STATUSES.indexOf(status) >= 0;
   }
 });

--- a/addon/serializers/web-api.js
+++ b/addon/serializers/web-api.js
@@ -56,27 +56,6 @@ export default DS.RESTSerializer.extend({
     }
   },
 
-  extractErrors: function (store, typeClass, payload, id) {
-    let strippedErrors = {},
-        payloadIsObject = payload && typeof payload === 'object';
-
-    if (payloadIsObject && payload.message) {
-      delete payload.message;
-    }
-
-    if (payload && typeof payload === 'object' && payload.modelState) {
-      Object.keys(payload.modelState).forEach(key => {
-        strippedErrors[key.replace(typeClass.modelName + '.','')] = payload.modelState[key];
-      });
-
-      payload.errors = this._errorsHashToArray(strippedErrors);
-
-      delete payload.modelState;
-    }
-
-    return this._super(store, typeClass, payload, id);
-  },
-
   sideloadItem: function(store, payload, type, record) {
     if (!(record instanceof Object)) {
       return false;
@@ -117,25 +96,4 @@ export default DS.RESTSerializer.extend({
       }
     });
   },
-
-  _errorsHashToArray: function (errors) {
-    let out = [];
-
-    if (Ember.isPresent(errors)) {
-      Object.keys(errors).forEach(function(key) {
-        let messages = Ember.makeArray(errors[key]);
-        for (let i = 0; i < messages.length; i++) {
-          out.push({
-            title: 'Invalid Attribute',
-            detail: messages[i],
-            source: {
-              pointer: `/data/attributes/${key}`
-            }
-          });
-        }
-      });
-    }
-
-    return out;
-  }
 });

--- a/addon/serializers/web-api.js
+++ b/addon/serializers/web-api.js
@@ -6,6 +6,11 @@ export default DS.RESTSerializer.extend({
   isNewSerializerAPI: true,
 
   normalizeResponse: function(store, primaryModelClass, payload, id, requestType) {
+    // If the response is empty, return the appropriate JSON API response.
+    // Unfortunately, this._super apparently doesn't support this condition properly.
+    // Based on the documentation at: http://jsonapi.org/format/
+    if(payload === null) { return { data: null }; }
+
     let payloadWithRoot = {},
         isCollection = payload.length > 0,
         key = isCollection ? pluralize(primaryModelClass.modelName) : primaryModelClass.modelName;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-inflector": "1.9.3",
+    "ember-inflector": "1.9.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "web-api-adapter"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3"
+    "ember-cli-babel": "^5.1.3",
+    "ember-inflector": "1.9.3",
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/serializers/web-api-test.js
+++ b/tests/unit/serializers/web-api-test.js
@@ -113,3 +113,13 @@ test('it extracts errors properly', function(assert) {
 
   assert.deepEqual(expected, parsed);
 });
+
+test('it handles an empty response properly', function(assert) {
+  let serializer = this.subject(),
+      type = this.store.modelFor('droid'),
+      response = null,
+      parsed = serializer.normalizeResponse(this.store, type, response, 1, 'findBelongsTo'),
+      expected = { data: null };
+
+  assert.deepEqual(expected, parsed);
+});

--- a/tests/unit/serializers/web-api-test.js
+++ b/tests/unit/serializers/web-api-test.js
@@ -93,27 +93,6 @@ test('it parses a basic hasMany relationship', function(assert) {
   assert.deepEqual(expected, parsed);
 });
 
-test('it extracts errors properly', function(assert) {
-  let serializer = this.subject(),
-      type = this.store.modelFor('droid'),
-      response = {
-        message: 'These are not the droids you are looking for.',
-        modelState: {
-          'droid.id': [
-            "That droid's id doesn't exist."
-          ]
-        }
-      },
-      parsed = serializer.extractErrors(this.store, type, response, 1),
-      expected = {
-        id: [
-          "That droid's id doesn't exist."
-        ]
-      };
-
-  assert.deepEqual(expected, parsed);
-});
-
 test('it handles an empty response properly', function(assert) {
   let serializer = this.subject(),
       type = this.store.modelFor('droid'),

--- a/tests/unit/serializers/web-api-test.js
+++ b/tests/unit/serializers/web-api-test.js
@@ -92,3 +92,24 @@ test('it parses a basic hasMany relationship', function(assert) {
 
   assert.deepEqual(expected, parsed);
 });
+
+test('it extracts errors properly', function(assert) {
+  let serializer = this.subject(),
+      type = this.store.modelFor('droid'),
+      response = {
+        message: 'These are not the droids you are looking for.',
+        modelState: {
+          'droid.id': [
+            "That droid's id doesn't exist."
+          ]
+        }
+      },
+      parsed = serializer.extractErrors(this.store, type, response, 1),
+      expected = {
+        id: [
+          "That droid's id doesn't exist."
+        ]
+      };
+
+  assert.deepEqual(expected, parsed);
+});


### PR DESCRIPTION
The current implementation of `isValid` has a bit of a nasty side-effect in that it formats the `payload` at the same time. Calling `isValid` should only do the necessary calculation. There is also some necessary logic that lingers in the serializer as well.

This refactor moves all of the munging logic for errors into a single location and performs the transformation as soon as the response comes back from the server. `isValid` now only performs the simple calculation to return the response as expected.
