### PR TITLE
Fix Ember Data 2.* Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js:
   - "0.12"
 
-sudo: false
-
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
   - "0.12"
 
+sudo: false
+
 cache:
   directories:
     - node_modules
@@ -27,10 +29,6 @@ install:
   - npm install -g bower
   - npm install
   - bower install
-  - sudo pip install codecov
 
 script:
   - ember try $EMBER_TRY_SCENARIO test
-
-after_success:
-  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - npm install -g bower
   - npm install
   - bower install
-  - pip install codecov
+  - sudo pip install codecov
 
 script:
   - ember try $EMBER_TRY_SCENARIO test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
-  - sudo pip install codecov
 
 install:
   - npm install -g bower
   - npm install
   - bower install
+  - pip install codecov
 
 script:
   - ember try $EMBER_TRY_SCENARIO test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
+  - pip install codecov
 
 install:
   - npm install -g bower
@@ -32,3 +33,6 @@ install:
 
 script:
   - ember try $EMBER_TRY_SCENARIO test
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
-  - pip install codecov
+  - sudo pip install codecov
 
 install:
   - npm install -g bower

--- a/addon/adapters/web-api.js
+++ b/addon/adapters/web-api.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 const VALIDATION_ERROR_STATUSES = [400, 422];
@@ -24,11 +25,11 @@ export default DS.RESTAdapter.extend({
 
     if (jsonIsObject && json.modelState) {
       Object.keys(json.modelState).forEach(key => {
-        let newKey = key.substring(key.indexOf('.') + 1).camelize();
+        let newKey = Ember.String.camelize(key.substring(key.indexOf('.') + 1));
         strippedErrors[newKey] = json.modelState[key];
       });
 
-      json.errors = strippedErrors;
+      json.errors = DS.errorsHashToArray(strippedErrors);
 
       delete json.modelState;
     }

--- a/addon/serializers/web-api.js
+++ b/addon/serializers/web-api.js
@@ -69,6 +69,10 @@ export default DS.RESTSerializer.extend({
       return true;
     }
 
+    record.attributes = Ember.copy(record, true);
+    record.type = type.modelName;
+    delete record.attributes.id;
+
     arr.push(record);
     payload[key] = arr;
     return true;

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-web-api",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.8",
+    "ember-data": "2.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
@@ -12,5 +12,8 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
+  },
+  "resolutions": {
+    "ember": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
-    "ember-cli": "1.13.8",
+    "ember-cli": "1.13.12",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
@@ -34,7 +34,7 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.8",
+    "ember-data": "2.1.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",

--- a/tests/index.html
+++ b/tests/index.html
@@ -26,6 +26,7 @@
     <script src="assets/dummy.js"></script>
     <script src="testem.js"></script>
     <script src="assets/test-loader.js"></script>
+    <script src="assets/tests.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}

--- a/tests/unit/adapters/web-api-test.js
+++ b/tests/unit/adapters/web-api-test.js
@@ -7,6 +7,23 @@ moduleFor('adapter:web-api', 'Unit | Adapter | web api', {
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
-  var adapter = this.subject();
-  assert.ok(adapter);
+  let error = {
+        message: 'An error has occurred',
+        modelState: {
+            'droid.Name': 'This name has already been taken'
+        }
+      },
+      adapter = this.subject(),
+      parsed = adapter.parseErrorResponse(JSON.stringify(error)),
+      expected = {
+        errors: [{
+          detail: 'This name has already been taken',
+          source: {
+            pointer: '/data/attributes/name'
+          },
+          title: 'Invalid Attribute'
+        }]
+      };
+
+  assert.deepEqual(parsed, expected);
 });

--- a/tests/unit/serializers/web-api-test.js
+++ b/tests/unit/serializers/web-api-test.js
@@ -35,7 +35,7 @@ test('it parses a simple record', function(assert) {
         included: []
       };
 
-  assert.deepEqual(expected, parsed);
+  assert.deepEqual(parsed, expected);
 });
 
 test('it parses a basic hasMany relationship', function(assert) {
@@ -90,7 +90,7 @@ test('it parses a basic hasMany relationship', function(assert) {
         }]
       };
 
-  assert.deepEqual(expected, parsed);
+  assert.deepEqual(parsed, expected);
 });
 
 test('it handles an empty response properly', function(assert) {
@@ -100,5 +100,5 @@ test('it handles an empty response properly', function(assert) {
       parsed = serializer.normalizeResponse(this.store, type, response, 1, 'findBelongsTo'),
       expected = { data: null };
 
-  assert.deepEqual(expected, parsed);
+  assert.deepEqual(parsed, expected);
 });


### PR DESCRIPTION
This PR addresses Issue #7.

To properly format the errors hash as a JSON API errors array, I use the built-in `errorsHashToArray` method from Ember Data.

I've also addressed an issue with one of the Unit Tests failing. Oddly enough, I haven't seen any issues with the Serializer in my current development application. I still need to verify that the changes to the serializer don't break anything in a production application.
