### PR TITLE
Added conversion between the different JSON property name casings in …

### DIFF
--- a/addon/serializers/web-api.js
+++ b/addon/serializers/web-api.js
@@ -18,6 +18,7 @@ export default DS.RESTSerializer.extend({
 
     if(isCollection) {
       payload.forEach((item) => {
+        this._mapRecord(item);
         this._extractRelationships(store, payloadWithRoot, item, primaryModelClass);
         item.attributes = Ember.copy(item, true);
         if(item.type) {
@@ -26,6 +27,7 @@ export default DS.RESTSerializer.extend({
         delete item.attributes.id;
       });
     } else {
+      this._mapRecord(payload);
       this._extractRelationships(store, payloadWithRoot, payload, primaryModelClass);
       payload.attributes = Ember.copy(payload, true);
       if(payload.type) {
@@ -40,10 +42,10 @@ export default DS.RESTSerializer.extend({
   serializeHasMany: function(snapshot, json, relationship) {
     let key = this.payloadKeyFromModelName(relationship.key);
     if (this._shouldSerializeHasMany(snapshot, key, relationship)) {
-      json[key] = [];
+      json[key.capitalize()] = [];
 
       snapshot.hasMany(relationship.key).forEach((i) => {
-        json[key].push(this.serialize(i, { includeId: true }));
+        json[key.capitalize()].push(this.serialize(i, { includeId: true }));
       });
     }
   },
@@ -60,7 +62,7 @@ export default DS.RESTSerializer.extend({
 
     for(prop in serialized) {
       if(serialized.hasOwnProperty(prop)) {
-        json[prop] = serialized[prop];
+        json[prop.capitalize()] = serialized[prop];
       }
     }
   },
@@ -108,5 +110,16 @@ export default DS.RESTSerializer.extend({
         }
       }
     });
+  },
+  
+  _mapRecord: function(record) {
+    var propertyName, value, newPropertyName;
+    let item = record;
+    for (propertyName in record) {
+      value = item[propertyName];
+      newPropertyName = propertyName.camelize();
+      item[newPropertyName] = value;
+      delete item[propertyName];
+    }
   },
 });


### PR DESCRIPTION
…JSON API and ASP.NET Web API

I was wondering why you change the JSON casing on the .NET WebAPI server side. I would prefer an approach either to only adopt Ember.js with adapter/serializer to speak to native .NET WebAPI or have the ASP.NET service return JSON API which is compatible with Ember Data.

Therefore I have adopted the code a bit to make it work without changing the JSON serialization on the ASP.NET application.

My versions: DNX 4.5.1, Asp.Net MVX 6.0.0-rc1-final, Ember 2.5.1, Ember Data 2.5.2

This may break backward-compatibility so it would be nice to have a configuration setting to enable/disable this conversion. But I am not very deeply into Ember.js yet and especially not addon development so maybe you can add something to have a switch?
