### PR TITLE
An addition control has been added for hasMany serializer checks.

### DIFF
--- a/addon/serializers/web-api.js
+++ b/addon/serializers/web-api.js
@@ -41,10 +41,11 @@ export default DS.RESTSerializer.extend({
     let key = this.payloadKeyFromModelName(relationship.key);
     if (this._shouldSerializeHasMany(snapshot, key, relationship)) {
       json[key] = [];
-
-      snapshot.hasMany(relationship.key).forEach((i) => {
-        json[key].push(this.serialize(i, { includeId: true }));
-      });
+      if(snapshot.hasMany(relationship.key)){
+        snapshot.hasMany(relationship.key).forEach((i) => {
+          json[key].push(this.serialize(i, { includeId: true }));
+        });
+      }
     }
   },
 


### PR DESCRIPTION
This control added because when I try to add an additional model serializer with embed options, it assumes there is a hasMany relation but function (snapshot.hasMany) returns undefined.
Example:

```
X Model:
     name: DS.attr(),
     attr: DS.hasMany('attr'),

Y Model:
   code: DS.attr(),
   xs: DS.belongsTo('X')

Y Serializer:
import ApplicationSerializer from './application';
import DS from 'ember-data';
export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
        xs: { embedded: 'always' },
    },
});

```

In example, I want to use embedded "xs" when I save model but it gets error due to X.attr.
